### PR TITLE
Move celery schedule out of `celeryconfig.py`

### DIFF
--- a/celeryconfig.py
+++ b/celeryconfig.py
@@ -1,8 +1,9 @@
 import copy
-from datetime import timedelta
 
-from openkongqi.source import get_sources
+from openkongqi.celery import get_schedule
 
+# Constants
+SECONDS_PER_MINUTE = 60
 
 # List of modules to import when celery starts.
 CELERY_IMPORTS = ('openkongqi.tasks', )
@@ -26,12 +27,4 @@ CELERY_TASK_SERIALIZER = 'json'
 CELERY_TIMEZONE = 'Asia/Shanghai'
 
 
-dyn_schedule = dict()
-for source in get_sources():
-    dyn_schedule[source['name']] = {
-        'task': 'openkongqi.tasks.fetch',
-        'schedule': timedelta(minutes=30),
-        'args': (source['name'], )
-    }
-
-CELERYBEAT_SCHEDULE = copy.copy(dyn_schedule)
+CELERYBEAT_SCHEDULE = copy.copy(get_schedule(seconds=30 * SECONDS_PER_MINUTE))

--- a/openkongqi/celery.py
+++ b/openkongqi/celery.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+
+from datetime import timedelta
+
+from .source import get_sources
+
+
+def get_schedule(seconds):
+    """Get celery schedule.
+    """
+    dyn_schedule = dict()
+    for source in get_sources():
+        dyn_schedule[source['name']] = {
+            'task': 'openkongqi.tasks.fetch',
+            'schedule': timedelta(seconds=seconds),
+            'args': (source['name'], )
+        }
+    return dyn_schedule

--- a/openkongqi/data/sources/pm25.in.json
+++ b/openkongqi/data/sources/pm25.in.json
@@ -2,7 +2,7 @@
     "shanghai": {
         "target": "http://pm25.in/shanghai",
         "uuid": "cn/shanghai",
-        "modname": "openkongqi.sources.pm25in",
+        "modname": "openkongqi.source.pm25in",
         "tz": "Asia/Shanghai"
     }
 }


### PR DESCRIPTION
By default, create schedules for all the sources. `timedelta` is the only parameter that can be user-specified.

Covers #5 
