### PR TITLE
Fix false negatives of empty content when fetching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: python
 python:
     - "2.7"
+install:
+    - pip install -r requirements-dev.txt
 script:
     - python -m unittest discover

--- a/openkongqi/source/base.py
+++ b/openkongqi/source/base.py
@@ -194,18 +194,27 @@ class HTTPSource(BaseSource):
                          .format(_common_error_header, e.message))
             return None
 
-        logger.info("Data successfully fetched.")
         self._info = resp.info()
         self._statuscode = resp.getcode()
         logger.debug("Fetch status: HTTP {}".format(self._statuscode))
 
-        content_length = resp.headers.get('content-length')
-        if (self._statuscode == 200 and
-            (content_length is None or content_length == 0)):
-            logger.warning("Fetched content is empty; skipping cache ...")
+        if self._statuscode == 204:  # 204: No Content
+            logger.warning("No message body included")
             return None
+
+        try:
+            # don't use `resp.headers.get('content-length`)
+            # because if it doesn't exist in headers it will return None
+            # which makes it a false negative
+            content_length = resp.headers['content-length']
+        except KeyError:
+            pass
         else:
-            return self.post_fetch(resp)
+            if (self._statuscode == 200 and content_length == '0'):
+                logger.warning("Fetched content is empty; skipping cache ...")
+                return None
+
+        return self.post_fetch(resp)
 
     def post_fetch(self, resource):
         return resource

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -6,3 +6,4 @@ flake8==2.5.4
 tox==2.3.1
 wheel==0.29.0
 twine==1.6.5
+httpretty==0.8.14

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,6 +18,7 @@ first==2.0.1              # via pip-tools
 flake8==2.5.4
 hiredis==0.2.0
 html5lib==0.99999
+httpretty==0.8.14
 Jinja2==2.8               # via sphinx
 kombu==3.0.33             # via celery
 MarkupSafe==0.23          # via jinja2

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+
+import httpretty
+import unittest
+from importlib import import_module
+
+
+class TestFetch(unittest.TestCase):
+
+    def setUp(self):
+        mod = import_module('openkongqi.source.' + 'pm25in')
+        src_name = 'pm25.in:shanghai'
+        self.src = mod.Source(src_name)
+
+    def tearDown(self):
+        httpretty.disable()
+        httpretty.reset()
+
+    @httpretty.activate
+    def test_nonempty_resp_with_0_content_length(self):
+        """Return none because content length is 0"""
+        url = "http://nonempty-resp-with-0-content-length.com"
+        httpretty.register_uri(
+            httpretty.GET, url,
+            body="This is NOT an empty response",
+            status=200,
+            content_type="text/html; charset=UTF-8",
+            forcing_headers={
+                'content-length': '0'
+            }
+        )
+
+        self.src.target = url
+        self.assertIsNone(self.src.fetch())
+
+    @httpretty.activate
+    def test_nonempty_resp_with_no_headers(self):
+        """Still return response because of potential false negative"""
+        url = "http://nonempty-resp-without-headers.com"
+        httpretty.register_uri(
+            httpretty.GET, url,
+            body="This is NOT an empty response",
+            status=200,
+            content_type="text/html; charset=UTF-8",
+            forcing_headers={}
+        )
+
+        self.src.target = url
+        self.assertIsNotNone(self.src.fetch())
+        self.assertEqual(self.src.fetch().read(),
+                         "This is NOT an empty response")
+
+    @httpretty.activate
+    def test_empty_resp(self):
+        """Empty response returns content-length of 0"""
+        url = "http://empty-resp.com"
+        httpretty.register_uri(
+            httpretty.GET, url,
+            body="",
+            status=200,
+        )
+
+        self.src.target = url
+        self.assertIsNone(self.src.fetch())


### PR DESCRIPTION
Sometimes sources will have valid, non-empty content but somehow don't have `content-length` in the response headers. 

Using `resp.headers.get('content-length')` would by default catch the `KeyError` exception and return `None`. This is not desired behavior because it could potentially be a false negative and it will break the extraction methods.

Now the code gets a little uglier but at least it performs as expected.
