### PR TITLE
Test records wrappers with mixins

### DIFF
--- a/openkongqi/__init__.py
+++ b/openkongqi/__init__.py
@@ -4,3 +4,18 @@
 __version__ = '0.0.8'
 __author__ = "Stefan Berder"
 __contact__ = 'stefan@measureofqualty.com'
+
+__all__ = [
+    'bin',
+    'cache',
+    'conf',
+    'exceptions',
+    'filecache',
+    'records',
+    'sched',
+    'source',
+    'stations',
+    'status',
+    'tasks',
+    'utils',
+]

--- a/openkongqi/cache/__init__.py
+++ b/openkongqi/cache/__init__.py
@@ -1,1 +1,6 @@
 # -*- coding: utf-8 -*-
+
+__all__ = [
+    'base',
+    'redisdb',
+]

--- a/openkongqi/records/__init__.py
+++ b/openkongqi/records/__init__.py
@@ -1,1 +1,9 @@
 # -*- coding: utf-8 -*-
+
+__all__ = [
+    'base',
+    'sqlalch',
+    'sqlite3',
+    'pgsql',
+    'mysql',
+]


### PR DESCRIPTION
The methods used for testing all share a common API.

The only thing that should be changed is how to setup differently based on the different records wrapper implementations.

Finally, correct the test(s) to actually use `moduuid` from context being passed around.
