### PR TITLE
create a task router based on source info

### DIFF
--- a/openkongqi/routes.py
+++ b/openkongqi/routes.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+from openkongqi.source import get_source
+
+
+def source_router(name, args, kwargs, options, task=None):
+    """
+    A dynamic router used to set a specific queue to scrape a source if the
+    source definition has a key named 'queue'.
+
+    .. code:: json
+
+        {
+          "taiwan": {
+            "target": "https://taqm.epa.gov.tw/pm25/en/PM25A.aspx?area=10",
+            "uuid": "tw",
+            "modname": "okq_gams.source.taqm",
+            "tz": "Asia/Taipei",
+            "queue": "taiwan"
+          }
+        }
+        
+    """
+    if name == 'openkongqi.tasks.scrape':
+        info = get_source(args[0])
+        if 'queue' in info:
+            return {
+                'queue': info['queue'],
+                'routing_key': info['queue'],
+            }
+        else:
+            return None


### PR DESCRIPTION
the router will set a custom queue based on the source configuration. If
the source object has a key calle queue, the scraping task for this
source will be sent to the specified queue.

Close #58